### PR TITLE
defect/fix prefer type valid js doc rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -479,10 +479,10 @@ module.exports = {
 				array: 'Array',
 				Boolean: 'boolean',
 				Integer: 'integer',
-				Number: 'number',
+				number: 'Number',
 				'function': 'Function',
 				object: 'Object',
-				String: 'string'
+				string: 'String'
 			},
 
 			// requires a return tag if and only if the function or method has a return statement (this option value does apply to constructors)


### PR DESCRIPTION
- Objects should always be upper cased and primitives lower cased.