### PR TITLE
Release/6.0.0

### DIFF
--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -1,12 +1,3 @@
 # @financialforcedev/eslint-config
 
 ## Latest changes (not yet released)
-
-### BREAKING CHANGES
-
-- Add the `@typescript-eslint/naming-convention` rule
-
-### OTHER CHANGES
-
-- Turn off the `no-use-before-define` rule for functions
-- Turn off the `no-unused-vars` rule for function arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @financialforcedev/eslint-config
 
+## 6.0.0
+
+### BREAKING CHANGES
+
+- Add the `@typescript-eslint/naming-convention` rule
+
+### OTHER CHANGES
+
+- Turn off the `no-use-before-define` rule for functions
+- Turn off the `no-unused-vars` rule for function arguments
+
 ## 5.0.0
 
 ### BREAKING CHANGES

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@financialforcedev/eslint-config",
-	"version": "5.0.0",
+	"version": "6.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,11 +55,11 @@
 			"integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.7.0.tgz",
-			"integrity": "sha512-4OEcPON3QIx0ntsuiuFP/TkldmBGXf0uKxPQlGtS/W2F3ndYm8Vgdpj/woPJkzUc65gd3iR+qi3K8SDQP/obFg==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.7.1.tgz",
+			"integrity": "sha512-3DB9JDYkMrc8Au00rGFiJLK2Ja9CoMP6Ut0sHsXp3ZtSugjNxvSSHTnKLfo4o+QmjYBJqEznDqsG1zj4F2xnsg==",
 			"requires": {
-				"@typescript-eslint/experimental-utils": "3.7.0",
+				"@typescript-eslint/experimental-utils": "3.7.1",
 				"debug": "^4.1.1",
 				"functional-red-black-tree": "^1.0.1",
 				"regexpp": "^3.0.0",
@@ -68,41 +68,41 @@
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.7.0.tgz",
-			"integrity": "sha512-xpfXXAfZqhhqs5RPQBfAFrWDHoNxD5+sVB5A46TF58Bq1hRfVROrWHcQHHUM9aCBdy9+cwATcvCbRg8aIRbaHQ==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.7.1.tgz",
+			"integrity": "sha512-TqE97pv7HrqWcGJbLbZt1v59tcqsSVpWTOf1AqrWK7n8nok2sGgVtYRuGXeNeLw3wXlLEbY1MKP3saB2HsO/Ng==",
 			"requires": {
 				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/types": "3.7.0",
-				"@typescript-eslint/typescript-estree": "3.7.0",
+				"@typescript-eslint/types": "3.7.1",
+				"@typescript-eslint/typescript-estree": "3.7.1",
 				"eslint-scope": "^5.0.0",
 				"eslint-utils": "^2.0.0"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.7.0.tgz",
-			"integrity": "sha512-2LZauVUt7jAWkcIW7djUc3kyW+fSarNEuM3RF2JdLHR9BfX/nDEnyA4/uWz0wseoWVZbDXDF7iF9Jc342flNqQ==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.7.1.tgz",
+			"integrity": "sha512-W4QV/gXvfIsccN8225784LNOorcm7ch68Fi3V4Wg7gmkWSQRKevO4RrRqWo6N/Z/myK1QAiGgeaXN57m+R/8iQ==",
 			"requires": {
 				"@types/eslint-visitor-keys": "^1.0.0",
-				"@typescript-eslint/experimental-utils": "3.7.0",
-				"@typescript-eslint/types": "3.7.0",
-				"@typescript-eslint/typescript-estree": "3.7.0",
+				"@typescript-eslint/experimental-utils": "3.7.1",
+				"@typescript-eslint/types": "3.7.1",
+				"@typescript-eslint/typescript-estree": "3.7.1",
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.7.0.tgz",
-			"integrity": "sha512-reCaK+hyKkKF+itoylAnLzFeNYAEktB0XVfSQvf0gcVgpz1l49Lt6Vo9x4MVCCxiDydA0iLAjTF/ODH0pbfnpg=="
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.7.1.tgz",
+			"integrity": "sha512-PZe8twm5Z4b61jt7GAQDor6KiMhgPgf4XmUb9zdrwTbgtC/Sj29gXP1dws9yEn4+aJeyXrjsD9XN7AWFhmnUfg=="
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.7.0.tgz",
-			"integrity": "sha512-xr5oobkYRebejlACGr1TJ0Z/r0a2/HUf0SXqPvlgUMwiMqOCu/J+/Dr9U3T0IxpE5oLFSkqMx1FE/dKaZ8KsOQ==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.7.1.tgz",
+			"integrity": "sha512-m97vNZkI08dunYOr2lVZOHoyfpqRs0KDpd6qkGaIcLGhQ2WPtgHOd/eVbsJZ0VYCQvupKrObAGTOvk3tfpybYA==",
 			"requires": {
-				"@typescript-eslint/types": "3.7.0",
-				"@typescript-eslint/visitor-keys": "3.7.0",
+				"@typescript-eslint/types": "3.7.1",
+				"@typescript-eslint/visitor-keys": "3.7.1",
 				"debug": "^4.1.1",
 				"glob": "^7.1.6",
 				"is-glob": "^4.0.1",
@@ -112,9 +112,9 @@
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.7.0.tgz",
-			"integrity": "sha512-k5PiZdB4vklUpUX4NBncn5RBKty8G3ihTY+hqJsCdMuD0v4jofI5xuqwnVcWxfv6iTm2P/dfEa2wMUnsUY8ODw==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.7.1.tgz",
+			"integrity": "sha512-xn22sQbEya+Utj2IqJHGLA3i1jDzR43RzWupxojbSWnj3nnPLavaQmWe5utw03CwYao3r00qzXfgJMGNkrzrAA==",
 			"requires": {
 				"eslint-visitor-keys": "^1.1.0"
 			}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@financialforcedev/eslint-config",
-	"version": "5.0.0",
+	"version": "6.0.0",
 	"description": "FinancialForce ESLint configuration",
 	"main": "index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
 	"author": "financialforce",
 	"license": "BSD-3-Clause",
 	"dependencies": {
-		"@typescript-eslint/eslint-plugin": "^3.7.0",
-		"@typescript-eslint/parser": "^3.7.0",
+		"@typescript-eslint/eslint-plugin": "^3.7.1",
+		"@typescript-eslint/parser": "^3.7.1",
 		"eslint": "^7.5.0",
 		"eslint-plugin-prettier": "^3.1.4",
 		"prettier": "^2.0.5",


### PR DESCRIPTION
## 6.0.0

### BREAKING CHANGES

- Add the `@typescript-eslint/naming-convention` rule

### OTHER CHANGES

- Turn off the `no-use-before-define` rule for functions
- Turn off the `no-unused-vars` rule for function arguments
